### PR TITLE
Improving the schedule page and adding team information

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,16 @@ model, you can install the requirements via `pip`:
 $ python -m pip install -r requirements.txt
 ```
 
-before setting an environment variable to indicate the path to your NBA data.
+before setting a environment variables, one to indicate the path to your NBA data
 
 ```console
 $ export DATA_DIR=nba-data
+```
+
+and a secret value
+
+```console
+$ export SECRET_KEY=mysecret
 ```
 
 # Usage

--- a/config.py
+++ b/config.py
@@ -7,8 +7,7 @@ class Config:
 
     STATIC_FOLDER = "static"
     TEMPLATES_FOLDER = "templates"
-    ASSETS_DEBUG = False
-    ASSETS_AUTO_BUILD = True
+    SECRET_KEY = os.environ.get("SECRET_KEY")
 
     # Data location
     DATA_DIR = os.environ.get("DATA_DIR")

--- a/nbaspa_app/__init__.py
+++ b/nbaspa_app/__init__.py
@@ -28,9 +28,11 @@ def create_app(config: str = "development"):
         from .games.routes import game_bp
         from .home.routes import home_bp
         from .schedule.routes import schedule_bp
+        from .teams.routes import teams_bp
 
         app.register_blueprint(game_bp)
         app.register_blueprint(home_bp)
         app.register_blueprint(schedule_bp)
+        app.register_blueprint(teams_bp)
 
         return app

--- a/nbaspa_app/games/summary.py
+++ b/nbaspa_app/games/summary.py
@@ -56,15 +56,36 @@ def create_lineplot(data: pd.DataFrame):
     Figure
         The figure object.
     """
-    with sns.axes_style("darkgrid"):
+    with sns.axes_style("dark"):
         fig, ax = plt.subplots()
         sns.lineplot(
-            x=META["duration"], y=META["survival"], data=data, ax=ax
+            x=META["duration"],
+            y=META["survival"],
+            color="blue",
+            data=data,
+            legend=False,
+            label="Win Probability",
+            ax=ax
         ).set(
             title=f"Win probability over gametime",
             xlabel="Time",
             ylabel="Home team win probability"
         )
+        ax2 = ax.twinx()
+        sns.lineplot(
+            x=META["duration"],
+            y="SCOREMARGIN",
+            data=data,
+            color="black",
+            legend=False,
+            label="Scoring margin",
+            palette="black",
+            linewidth=0.5,
+            ax=ax2
+        ).set(
+            ylabel="Score margin"
+        )
         ax.yaxis.set_major_formatter(ticker.PercentFormatter(xmax=1))
+        ax.figure.legend()
     
     return fig

--- a/nbaspa_app/games/templates/game.html
+++ b/nbaspa_app/games/templates/game.html
@@ -5,12 +5,16 @@
         <tbody>
             <tr>
                 <td style="text-align: left;">
-                    <img src="https://cdn.nba.com/logos/nba/{{ teambox.loc[1, 'TEAM_ID'] }}/primary/L/logo.svg" width="100px">
+                    <a href="{{ url_for('teams_bp.team_summary', teamid=teambox.loc[1, 'TEAM_ID']) }}">
+                        <img src="https://cdn.nba.com/logos/nba/{{ teambox.loc[1, 'TEAM_ID'] }}/primary/L/logo.svg" width="100px">
+                    </a>
                 </td>
                 <td style="text-align: right;">{{ teambox.loc[1, 'PTS'] }}</td>
                 <td style="text-align: left;">{{ teambox.loc[0, 'PTS'] }}</td>
                 <td style="text-align: right;">
-                    <img src="https://cdn.nba.com/logos/nba/{{ teambox.loc[0, 'TEAM_ID'] }}/primary/L/logo.svg" width="100px">
+                    <a href="{{ url_for('teams_bp.team_summary', teamid=teambox.loc[0, 'TEAM_ID']) }}">
+                        <img src="https://cdn.nba.com/logos/nba/{{ teambox.loc[0, 'TEAM_ID'] }}/primary/L/logo.svg" width="100px">
+                    </a>
                 </td>
             </tr>
         </tbody>

--- a/nbaspa_app/home/routes.py
+++ b/nbaspa_app/home/routes.py
@@ -17,5 +17,5 @@ def home():
     """Homepage."""
     return render_template(
         "home.html",
-        title="My Demo Title",
+        title="NBA SPA",
     )

--- a/nbaspa_app/schedule/forms.py
+++ b/nbaspa_app/schedule/forms.py
@@ -1,0 +1,11 @@
+"""Create a form for picking the schedule date."""
+
+from flask_wtf import FlaskForm
+from wtforms import SubmitField
+from wtforms.fields.html5 import DateField
+
+class ScheduleDatePicker(FlaskForm):
+    """Create a form for selecting the schedule date."""
+
+    gamedate = DateField("DatePicker", format="%Y-%m-%d")
+    submit = SubmitField("Go")

--- a/nbaspa_app/schedule/routes.py
+++ b/nbaspa_app/schedule/routes.py
@@ -4,9 +4,9 @@ from datetime import datetime
 
 from flask import Blueprint, redirect, render_template, url_for
 from flask import current_app as app
-import pandas as pd
 
 from .calendar import get_data, create_list
+from .forms import ScheduleDatePicker
 
 TODAY = datetime.today()
 
@@ -17,8 +17,25 @@ schedule_bp = Blueprint(
     static_folder=app.config["STATIC_FOLDER"]
 )
 
+
+@schedule_bp.post("/schedule")
+def picker():
+    """Using the datepicker to redirect to the correct day."""
+    form = ScheduleDatePicker()
+    gamedate = form.gamedate.data
+
+    return redirect(
+        url_for(
+            "schedule_bp.schedule",
+            day=gamedate.day,
+            month=gamedate.month,
+            year=gamedate.year
+        )
+    )
+
 @schedule_bp.get(
-    "/schedule", defaults={"day": TODAY.day, "month": TODAY.month, "year": TODAY.year}
+    "/schedule",
+    defaults={"day": TODAY.day, "month": TODAY.month, "year": TODAY.year}
 )
 @schedule_bp.get("/schedule/<int:day>/<int:month>/<int:year>")
 def schedule(day: int, month: int, year: int):
@@ -33,6 +50,7 @@ def schedule(day: int, month: int, year: int):
     year : int
         The year of the games.
     """
+    form = ScheduleDatePicker()
     gamedate = datetime(year=year, month=month, day=day)
     scoreboard = get_data(app=app, GameDate=gamedate)
     if scoreboard.exists():
@@ -43,6 +61,7 @@ def schedule(day: int, month: int, year: int):
     return render_template(
         "schedule.html",
         title="Game Schedule",
+        form=form,
         gamedate=gamedate.strftime("%A, %B %d, %Y"),
         data=[datalist[i:i+3] for i in range(0, len(datalist), 3)]
     )

--- a/nbaspa_app/schedule/templates/schedule.html
+++ b/nbaspa_app/schedule/templates/schedule.html
@@ -25,14 +25,18 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        <img src="https://cdn.nba.com/logos/nba/{{ game['home_id'] }}/primary/L/logo.svg" width="50px">
+                                        <a href="{{ url_for('teams_bp.team_summary', teamid=game['home_id']) }}">
+                                            <img src="https://cdn.nba.com/logos/nba/{{ game['home_id'] }}/primary/L/logo.svg" width="50px">
+                                        </a>
                                     </td>
                                     <td>{{ game['home_abbrev'] }}</td>
                                     <td>{{ game['home_pts'] }}</td>
                                 </tr>
                                 <tr>
                                     <td>
-                                        <img src="https://cdn.nba.com/logos/nba/{{ game['visitor_id'] }}/primary/L/logo.svg" width="50px">
+                                        <a href="{{ url_for('teams_bp.team_summary', teamid=game['visitor_id']) }}">
+                                            <img src="https://cdn.nba.com/logos/nba/{{ game['visitor_id'] }}/primary/L/logo.svg" width="50px">
+                                        </a>
                                     </td>
                                     <td>{{ game['visitor_abbrev'] }}</td>
                                     <td>{{ game['visitor_pts'] }}</td>

--- a/nbaspa_app/schedule/templates/schedule.html
+++ b/nbaspa_app/schedule/templates/schedule.html
@@ -2,7 +2,20 @@
 
 {% block content %}
     <br>
-    <h4 class="title">Games for {{ gamedate }}</h2>
+    <h4 class="title">Games for {{ gamedate }}</h4>
+    <form method="POST" action="{{ url_for('schedule_bp.schedule') }}">
+        <fieldset class="form-field">
+            {{ form.gamedate }}
+            {% if form.gamedate.errors %}
+                <ul class="errors">
+                    {% for error in form.gamedate.errors %}
+                        <li>{{ error }}</li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
+        </fieldset>
+        {{ form.submit }}
+    </form>
     <div class="container">
         {% for seg in data %}
             <div class="row">

--- a/nbaspa_app/static/dist/css/custom.css
+++ b/nbaspa_app/static/dist/css/custom.css
@@ -5,6 +5,10 @@
     margin-top: 6rem;
     text-align: center;
 }
+.header-img {
+    position: relative;
+    height: 200px;
+}
 .value-prop {
     margin-top: 1rem;
 }

--- a/nbaspa_app/teams/__init__.py
+++ b/nbaspa_app/teams/__init__.py
@@ -1,0 +1,1 @@
+"""Import path."""

--- a/nbaspa_app/teams/data.py
+++ b/nbaspa_app/teams/data.py
@@ -4,8 +4,9 @@ from pathlib import Path
 from typing import Dict, List
 
 from flask import Flask
-from nbaspa.data.endpoints import TeamGameLog, TeamStats
+from nbaspa.data.endpoints import AllPlayers, TeamGameLog, TeamStats
 from nbaspa.data.endpoints.parameters import SEASONS
+import pandas as pd
 
 def gen_teamlist(app: Flask) -> List[Dict]:
     """Generate the team list.
@@ -74,7 +75,7 @@ def gen_summarymetrics(app: Flask, teamid: int) -> List[Dict]:
     return output
 
 
-def gen_gamelog(app: Flask, teamid: int, season: str) -> List[Dict]:
+def gen_gamelog(app: Flask, teamid: int, season: str) -> pd.DataFrame:
     """Get the gamelog for a given team in a season.
 
     Parameters
@@ -88,8 +89,8 @@ def gen_gamelog(app: Flask, teamid: int, season: str) -> List[Dict]:
     
     Returns
     -------
-    List
-        A list with one dictionary per game.
+    pd.DataFrame
+        The data.
     """
     loader = TeamGameLog(
         output_dir=Path(app.config["DATA_DIR"], season),
@@ -100,3 +101,31 @@ def gen_gamelog(app: Flask, teamid: int, season: str) -> List[Dict]:
     data = loader.get_data()
 
     return data
+
+
+def gen_roster(app: Flask, teamid: int, season: str) -> pd.DataFrame:
+    """Get the roster for a given team in a season.
+
+    Parameters
+    ----------
+    app : Flask
+        The current application
+    teamid : int
+        The team identifier.
+    season : str
+        The season.
+    
+    Returns
+    -------
+    pd.DataFrame
+        The data.
+    """
+    loader = AllPlayers(
+        output_dir=Path(app.config["DATA_DIR"], season),
+        Season=season
+    )
+    loader.load()
+
+    data = loader.get_data()
+    
+    return data[data["TEAM_ID"] == teamid].copy().reset_index(drop=True)

--- a/nbaspa_app/teams/data.py
+++ b/nbaspa_app/teams/data.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Dict, List
 
 from flask import Flask
-from nbaspa.data.endpoints import TeamStats
+from nbaspa.data.endpoints import TeamGameLog, TeamStats
 from nbaspa.data.endpoints.parameters import SEASONS
 
 def gen_teamlist(app: Flask) -> List[Dict]:
@@ -72,3 +72,31 @@ def gen_summarymetrics(app: Flask, teamid: int) -> List[Dict]:
         )
 
     return output
+
+
+def gen_gamelog(app: Flask, teamid: int, season: str) -> List[Dict]:
+    """Get the gamelog for a given team in a season.
+
+    Parameters
+    ----------
+    app : Flask
+        The current application.
+    teamid : int
+        The team identifier.
+    season : str
+        The season.
+    
+    Returns
+    -------
+    List
+        A list with one dictionary per game.
+    """
+    loader = TeamGameLog(
+        output_dir=Path(app.config["DATA_DIR"], season),
+        TeamID=teamid,
+        Season=season
+    )
+    loader.load()
+    data = loader.get_data()
+
+    return data

--- a/nbaspa_app/teams/data.py
+++ b/nbaspa_app/teams/data.py
@@ -1,0 +1,37 @@
+"""Reading in the team data."""
+
+from pathlib import Path
+from typing import Dict, List
+
+from flask import Flask
+from nbaspa.data.endpoints import TeamStats
+from nbaspa.data.endpoints.parameters import SEASONS
+
+def gen_teamlist(app: Flask) -> List[Dict]:
+    """Generate the team list.
+
+    Parameters
+    ----------
+    app : Flask
+        The current application.
+    
+    Returns
+    -------
+    List
+        A list of dictionaries with the team ID and team name.
+    """
+    allseasons = list(SEASONS.keys())
+    currseason = sorted(allseasons)[-1]
+    loader = TeamStats(
+        output_dir=Path(app.config["DATA_DIR"], currseason),
+        Season=currseason
+    )
+    loader.load()
+    data = loader.get_data()
+    data.sort_values(by="TEAM_NAME", ascending=True, inplace=True)
+
+    output = []
+    for _, row in data.iterrows():
+        output.append({"teamid": row["TEAM_ID"], "teamname": row["TEAM_NAME"]})
+    
+    return output

--- a/nbaspa_app/teams/data.py
+++ b/nbaspa_app/teams/data.py
@@ -35,3 +35,40 @@ def gen_teamlist(app: Flask) -> List[Dict]:
         output.append({"teamid": row["TEAM_ID"], "teamname": row["TEAM_NAME"]})
     
     return output
+
+
+def gen_summarymetrics(app: Flask, teamid: int) -> List[Dict]:
+    """Generate summary metrics for each team.
+
+    Parameters
+    ----------
+    app : Flask
+        The current application.
+    teamid : int
+        The team identifier.
+    
+    Returns
+    -------
+    List
+        A list with one dictionary per team.
+    """
+    output = []
+    allseasons = list(SEASONS.keys())
+    allseasons.sort(reverse=True)
+    for season in allseasons:
+        loader = TeamStats(
+            output_dir=Path(app.config["DATA_DIR"], season),
+            Season=season
+        )
+        loader.load()
+        data = loader.get_data()
+        data.set_index("TEAM_ID", inplace=True)
+        output.append(
+            {
+                "season": season,
+                "record": f"{data.loc[teamid, 'W']}-{data.loc[teamid, 'L']}",
+                "net_rating": data.loc[teamid, "E_NET_RATING"],
+            }
+        )
+
+    return output

--- a/nbaspa_app/teams/routes.py
+++ b/nbaspa_app/teams/routes.py
@@ -64,6 +64,7 @@ def team_gamelog(teamid: int, season: int):
     teamlist = gen_teamlist(app=app)
     teamname = [row["teamname"] for row in teamlist if row["teamid"] == teamid][0]
     data = gen_gamelog(app=app, teamid=teamid, season=season)
+    data["W_PCT"] = (data["W_PCT"] * 100).round(1)
     return render_template(
         "gamelog.html",
         season=season,

--- a/nbaspa_app/teams/routes.py
+++ b/nbaspa_app/teams/routes.py
@@ -4,7 +4,12 @@ from flask import Blueprint, render_template
 from flask import current_app as app
 from nbaspa.data.endpoints.parameters import SEASONS
 
-from .data import gen_teamlist, gen_summarymetrics, gen_gamelog
+from .data import (
+    gen_teamlist,
+    gen_summarymetrics,
+    gen_gamelog,
+    gen_roster
+)
 
 teams_bp = Blueprint(
     "teams_bp",
@@ -80,7 +85,14 @@ def team_players(teamid: int, season: int):
     season : int
         The season year.
     """
+    roster = gen_roster(app=app, teamid=teamid, season=season)
+    roster.sort_values(by="DISPLAY_LAST_COMMA_FIRST", ascending=True, inplace=True)
+    teamname = f"{roster.loc[0, 'TEAM_CITY']} {roster.loc[0, 'TEAM_NAME']}"
     return render_template(
         "players.html",
-        title=f"{season} Roster"
+        title=f"{season} Roster",
+        teamid=teamid,
+        teamname=teamname,
+        season=season,
+        data=roster
     )

--- a/nbaspa_app/teams/routes.py
+++ b/nbaspa_app/teams/routes.py
@@ -2,8 +2,9 @@
 
 from flask import Blueprint, render_template
 from flask import current_app as app
+from nbaspa.data.endpoints.parameters import SEASONS
 
-from .data import gen_teamlist
+from .data import gen_teamlist, gen_summarymetrics
 
 teams_bp = Blueprint(
     "teams_bp",
@@ -32,15 +33,20 @@ def team_summary(teamid: int):
     team_id : int
         The team identifier.
     """
+    teamlist = gen_teamlist(app=app)
+    teamname = [row["teamname"] for row in teamlist if row["teamid"] == teamid][0]
+    summarydata = gen_summarymetrics(app=app, teamid=teamid)
     return render_template(
         "summary.html",
-        title="Summary",
-        teamid=teamid
+        title=teamname,
+        teamid=teamid,
+        teamname=teamname,
+        data=summarydata
     )
 
 
-@teams_bp.get("/teams/<int:team_id>/<int:season>/gamelog")
-def team_gamelog(team_id: int, season: int):
+@teams_bp.get("/teams/<int:teamid>/<season>/gamelog")
+def team_gamelog(teamid: int, season: int):
     """The team gamelog for a given season.
 
     Parameters
@@ -56,8 +62,8 @@ def team_gamelog(team_id: int, season: int):
     )
 
 
-@teams_bp.get("/teams/<int:team_id>/<int:season>/players")
-def team_players(team_id: int, season: int):
+@teams_bp.get("/teams/<int:teamid>/<season>/players")
+def team_players(teamid: int, season: int):
     """The team roster.
 
     Parameters
@@ -69,5 +75,5 @@ def team_players(team_id: int, season: int):
     """
     return render_template(
         "players.html",
-        title="{season} Roster"
+        title=f"{season} Roster"
     )

--- a/nbaspa_app/teams/routes.py
+++ b/nbaspa_app/teams/routes.py
@@ -3,6 +3,8 @@
 from flask import Blueprint, render_template
 from flask import current_app as app
 
+from .data import gen_teamlist
+
 teams_bp = Blueprint(
     "teams_bp",
     __name__,
@@ -13,9 +15,11 @@ teams_bp = Blueprint(
 @teams_bp.get("/teams")
 def teams_home():
     """Team homepage."""
+    teamlist = gen_teamlist(app=app)
     return render_template(
         "team_nav.html",
         title="Teams",
+        teamlist=[teamlist[i:i+6] for i in range(0, len(teamlist), 6)]
     )
 
 

--- a/nbaspa_app/teams/routes.py
+++ b/nbaspa_app/teams/routes.py
@@ -4,7 +4,7 @@ from flask import Blueprint, render_template
 from flask import current_app as app
 from nbaspa.data.endpoints.parameters import SEASONS
 
-from .data import gen_teamlist, gen_summarymetrics
+from .data import gen_teamlist, gen_summarymetrics, gen_gamelog
 
 teams_bp = Blueprint(
     "teams_bp",
@@ -56,9 +56,16 @@ def team_gamelog(teamid: int, season: int):
     season : int
         The season year.
     """
+    teamlist = gen_teamlist(app=app)
+    teamname = [row["teamname"] for row in teamlist if row["teamid"] == teamid][0]
+    data = gen_gamelog(app=app, teamid=teamid, season=season)
     return render_template(
         "gamelog.html",
-        title=f"{season} Gamelog"
+        season=season,
+        title=f"{teamname} - {season} Gamelog",
+        teamid=teamid,
+        teamname=teamname,
+        data=data
     )
 
 

--- a/nbaspa_app/teams/routes.py
+++ b/nbaspa_app/teams/routes.py
@@ -1,0 +1,69 @@
+"""Team information."""
+
+from flask import Blueprint, render_template
+from flask import current_app as app
+
+teams_bp = Blueprint(
+    "teams_bp",
+    __name__,
+    template_folder=app.config["TEMPLATES_FOLDER"],
+    static_folder=app.config["STATIC_FOLDER"]
+)
+
+@teams_bp.get("/teams")
+def teams_home():
+    """Team homepage."""
+    return render_template(
+        "team_nav.html",
+        title="Teams",
+    )
+
+
+@teams_bp.get("/teams/<int:teamid>")
+def team_summary(teamid: int):
+    """The team summary.
+
+    Parameters
+    ----------
+    team_id : int
+        The team identifier.
+    """
+    return render_template(
+        "summary.html",
+        title="Summary",
+        teamid=teamid
+    )
+
+
+@teams_bp.get("/teams/<int:team_id>/<int:season>/gamelog")
+def team_gamelog(team_id: int, season: int):
+    """The team gamelog for a given season.
+
+    Parameters
+    ----------
+    team_id : int
+        The team identifier.
+    season : int
+        The season year.
+    """
+    return render_template(
+        "gamelog.html",
+        title=f"{season} Gamelog"
+    )
+
+
+@teams_bp.get("/teams/<int:team_id>/<int:season>/players")
+def team_players(team_id: int, season: int):
+    """The team roster.
+
+    Parameters
+    ----------
+    team_id : int
+        The team identifier.
+    season : int
+        The season year.
+    """
+    return render_template(
+        "players.html",
+        title="{season} Roster"
+    )

--- a/nbaspa_app/teams/templates/gamelog.html
+++ b/nbaspa_app/teams/templates/gamelog.html
@@ -1,0 +1,4 @@
+{% extends 'layout.html' %}
+
+{% block content %}
+{% endblock %}

--- a/nbaspa_app/teams/templates/gamelog.html
+++ b/nbaspa_app/teams/templates/gamelog.html
@@ -1,4 +1,34 @@
 {% extends 'layout.html' %}
 
 {% block content %}
+    <div style="text-align: center;">
+        <img class="header-img" src="https://cdn.nba.com/logos/nba/{{ teamid }}/primary/L/logo.svg">
+        <h2 class="title">{{ teamname }} - {{ season }} Gamelog</h2>
+    </div>
+    <div class="container">
+        <table class="u-full-width">
+            <thead>
+                <tr>
+                    <td>Game Date</td>
+                    <td>Matchup</td>
+                    <td>Result</td>
+                    <td>Win Percentage</td>
+                </tr>
+            </thead>
+            <tbody>
+                {% for _, row in data.iterrows() %}
+                    <tr>
+                        <td>{{ row['GAME_DATE'] }}</td>
+                        <td>
+                            <a href="{{ url_for('game_bp.game', gameid=row['Game_ID']) }}">
+                                {{ row['MATCHUP'] }}
+                            </a>
+                        </td>
+                        <td>{{ row['WL'] }}</td>
+                        <td>{{ row['W_PCT'] }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
 {% endblock %}

--- a/nbaspa_app/teams/templates/gamelog.html
+++ b/nbaspa_app/teams/templates/gamelog.html
@@ -1,10 +1,6 @@
-{% extends 'layout.html' %}
+{% extends 'team_layout.html' %}
 
-{% block content %}
-    <div style="text-align: center;">
-        <img class="header-img" src="https://cdn.nba.com/logos/nba/{{ teamid }}/primary/L/logo.svg">
-        <h2 class="title">{{ teamname }} - {{ season }} Gamelog</h2>
-    </div>
+{% block datacontent %}
     <div class="container">
         <table class="u-full-width">
             <thead>

--- a/nbaspa_app/teams/templates/gamelog.html
+++ b/nbaspa_app/teams/templates/gamelog.html
@@ -1,5 +1,7 @@
 {% extends 'team_layout.html' %}
 
+{% block subtitle %}{{ teamname }} {{ season }} Gamelog{% endblock %}
+
 {% block datacontent %}
     <div class="container">
         <table class="u-full-width">
@@ -21,7 +23,7 @@
                             </a>
                         </td>
                         <td>{{ row['WL'] }}</td>
-                        <td>{{ row['W_PCT'] }}</td>
+                        <td>{{ row['W_PCT'] }}%</td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/nbaspa_app/teams/templates/players.html
+++ b/nbaspa_app/teams/templates/players.html
@@ -1,0 +1,4 @@
+{% extends 'layout.html' %}
+
+{% block content %}
+{% endblock %}

--- a/nbaspa_app/teams/templates/players.html
+++ b/nbaspa_app/teams/templates/players.html
@@ -1,4 +1,24 @@
-{% extends 'layout.html' %}
+{% extends 'team_layout.html' %}
 
-{% block content %}
+{% block datacontent %}
+    <div class="container">
+        <table class="u-full-width">
+            <thead>
+                <tr>
+                    <td></td>
+                    <td></td>
+                </tr>
+            </thead>
+            {% for _, row in data.iterrows() %}
+                <tr>
+                    <td>
+                        <img src="https://cdn.nba.com/headshots/nba/latest/260x190/{{ row['PERSON_ID'] }}.png" height="100px">
+                    </td>
+                    <td>
+                        {{ row['DISPLAY_FIRST_LAST'] }}
+                    </td>
+                </tr>
+            {% endfor %}
+        </table>
+    </div>
 {% endblock %}

--- a/nbaspa_app/teams/templates/players.html
+++ b/nbaspa_app/teams/templates/players.html
@@ -1,5 +1,7 @@
 {% extends 'team_layout.html' %}
 
+{% block subtitle %}{{ teamname }} {{ season }} Roster{% endblock %}
+
 {% block datacontent %}
     <div class="container">
         <table class="u-full-width">

--- a/nbaspa_app/teams/templates/summary.html
+++ b/nbaspa_app/teams/templates/summary.html
@@ -1,0 +1,5 @@
+{% extends 'layout.html' %}
+
+{% block content %}
+    <img src="https://cdn.nba.com/logos/nba/{{ teamid }}/primary/L/logo.svg" width="50px">
+{% endblock %}

--- a/nbaspa_app/teams/templates/summary.html
+++ b/nbaspa_app/teams/templates/summary.html
@@ -1,5 +1,40 @@
 {% extends 'layout.html' %}
 
 {% block content %}
-    <img src="https://cdn.nba.com/logos/nba/{{ teamid }}/primary/L/logo.svg" width="50px">
+    <div style="text-align: center;">
+        <img class="header-img" src="https://cdn.nba.com/logos/nba/{{ teamid }}/primary/L/logo.svg">
+        <h2 class="title">{{ teamname }}</h2>
+    </div>
+    <div class="container">
+        <table class="u-full-width">
+            <thead>
+                <tr>
+                    <td>Season</td>
+                    <td>Record</td>
+                    <td>Net Rating</td>
+                    <td></td>
+                    <td></td>
+                </tr>
+            </thead>
+            <tbody>
+                {% for row in data %}
+                    <tr>
+                        <td>{{ row['season'] }}</td>
+                        <td>{{ row['record'] }}</td>
+                        <td>{{ row['net_rating'] }}</td>
+                        <td>
+                            <a href="{{ url_for('teams_bp.team_gamelog', teamid=teamid, season=row['season']) }}">
+                                Gamelog
+                            </a>
+                        </td>
+                        <td>
+                            <a href="{{ url_for('teams_bp.team_players', teamid=teamid, season=row['season']) }}">
+                                Roster
+                            </a>
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
 {% endblock %}

--- a/nbaspa_app/teams/templates/summary.html
+++ b/nbaspa_app/teams/templates/summary.html
@@ -1,10 +1,6 @@
-{% extends 'layout.html' %}
+{% extends 'team_layout.html' %}
 
-{% block content %}
-    <div style="text-align: center;">
-        <img class="header-img" src="https://cdn.nba.com/logos/nba/{{ teamid }}/primary/L/logo.svg">
-        <h2 class="title">{{ teamname }}</h2>
-    </div>
+{% block datacontent %}
     <div class="container">
         <table class="u-full-width">
             <thead>

--- a/nbaspa_app/teams/templates/team_layout.html
+++ b/nbaspa_app/teams/templates/team_layout.html
@@ -4,7 +4,7 @@
     {% block imagehead %}
         <div style="text-align: center;">
             <img class="header-img" src="https://cdn.nba.com/logos/nba/{{ teamid }}/primary/L/logo.svg">
-            <h2 class="title">{{ teamname }}</h2>
+            <h2 class="title">{% block subtitle %}{{ teamname }}{% endblock %}</h2>
         </div>
     {% endblock %}
     {% block datacontent %}{% endblock %}

--- a/nbaspa_app/teams/templates/team_layout.html
+++ b/nbaspa_app/teams/templates/team_layout.html
@@ -1,0 +1,11 @@
+{% extends 'layout.html' %}
+
+{% block content %}
+    {% block imagehead %}
+        <div style="text-align: center;">
+            <img class="header-img" src="https://cdn.nba.com/logos/nba/{{ teamid }}/primary/L/logo.svg">
+            <h2 class="title">{{ teamname }}</h2>
+        </div>
+    {% endblock %}
+    {% block datacontent %}{% endblock %}
+{% endblock %}

--- a/nbaspa_app/teams/templates/team_nav.html
+++ b/nbaspa_app/teams/templates/team_nav.html
@@ -1,0 +1,4 @@
+{% extends 'layout.html' %}
+
+{% block content %}
+{% endblock %}

--- a/nbaspa_app/teams/templates/team_nav.html
+++ b/nbaspa_app/teams/templates/team_nav.html
@@ -1,4 +1,18 @@
 {% extends 'layout.html' %}
 
 {% block content %}
+    {% for row in teamlist %}
+        <div class="row">
+            {% for team in row %}
+                <div class="two columns">
+                    <figure>
+                        <a href="{{ url_for('teams_bp.team_summary', teamid=team['teamid']) }}">
+                            <img src="https://cdn.nba.com/logos/nba/{{ team['teamid'] }}/primary/L/logo.svg" width="100px">
+                        </a>
+                        <figcaption>{{ team['teamname'] }}</figcaption>
+                    </figure>
+                </div>
+            {% endfor %}
+        </div>
+    {% endfor %}
 {% endblock %}

--- a/nbaspa_app/templates/layout.html
+++ b/nbaspa_app/templates/layout.html
@@ -32,6 +32,7 @@
                         <li class="navbar-item">
                             <a class="navbar-link" href="{{ url_for('home_bp.home') }}">Home</a>
                             <a class="navbar-link" href="{{ url_for('schedule_bp.schedule') }}">Schedule</a>
+                            <a class="navbar-link" href="{{ url_for('teams_bp.teams_home') }}">Teams</a>
                         </li>
                     </ul>
                 </div>

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 Click>=7.1.2,<=8.0.1
 Flask>=2.0.0,<=2.0.1
-flask-assets==2.0
+flask-wtf>=0.15.0,<=0.15.1
 Jinja2>=3.0.0,<=3.0.1
 nbaspa@git+https://github.com/ak-gupta/nbaspa

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,12 +50,12 @@ distributed==2021.6.0
     # via prefect
 docker==5.0.0
     # via prefect
-flask-assets==2.0
+flask-wtf==0.15.1
     # via -r requirements.in
 flask==2.0.1
     # via
     #   -r requirements.in
-    #   flask-assets
+    #   flask-wtf
 formulaic==0.2.3
     # via lifelines
 fsspec==0.8.5
@@ -81,7 +81,9 @@ ipython-genutils==0.2.0
 ipython==7.24.1
     # via shap
 itsdangerous==2.0.1
-    # via flask
+    # via
+    #   flask
+    #   flask-wtf
 jedi==0.18.0
     # via ipython
 jinja2==3.0.1
@@ -101,7 +103,9 @@ llvmlite==0.36.0
 locket==0.2.1
     # via partd
 markupsafe==2.0.1
-    # via jinja2
+    # via
+    #   jinja2
+    #   wtforms
 marshmallow-oneofschema==2.1.0
     # via prefect
 marshmallow==3.12.1
@@ -265,8 +269,6 @@ urllib3==1.26.5
     #   requests
 wcwidth==0.2.5
     # via prompt-toolkit
-webassets==2.0
-    # via flask-assets
 websocket-client==1.1.0
     # via docker
 werkzeug==2.0.1
@@ -275,6 +277,8 @@ wheel==0.36.2
     # via lightgbm
 wrapt==1.12.1
     # via formulaic
+wtforms==2.3.3
+    # via flask-wtf
 xgboost==1.3.3
     # via nbaspa
 zict==2.0.0


### PR DESCRIPTION
In this PR, I've

* Used `flask-wtf` to create a datepicker that makes navigating the schedule easier, and
* Added a set of teams pages, including roster information, gamelog, and team navigation